### PR TITLE
Add waila compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,28 +37,16 @@ minecraft {
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
+repositories {
+    //WAILA
+    maven {
+        name "Mobius Repo"
+        url "http://mobiusstrip.eu/maven"
+    }
+}
+
 dependencies {
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
-
-    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
-    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // the deobf configurations:  'deobfCompile' and 'deobfProvided' are the same as the normal compile and provided,
-    // except that these dependencies get remapped to your current MCP mappings
-    //deobfCompile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-    //deobfProvided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
-
+    deobfCompile "mcp.mobius.waila:Waila:1.7.0-B3_1.9.4"
 }
 
 processResources

--- a/src/main/java/com/agriculturalexpansion/compat/WailaDataProvider.java
+++ b/src/main/java/com/agriculturalexpansion/compat/WailaDataProvider.java
@@ -1,0 +1,49 @@
+package com.agriculturalexpansion.compat;
+
+import com.agriculturalexpansion.extend.AECrop;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.List;
+
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.IWailaRegistrar;
+
+public class WailaDataProvider implements IWailaDataProvider {
+
+    public static void callbackRegister(IWailaRegistrar registrar) {
+        registrar.registerStackProvider(new WailaDataProvider(), AECrop.class);
+    }
+
+    @Override
+    public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
+        return new ItemStack(accessor.getBlock());
+    }
+
+    @Override
+    public List<String> getWailaHead(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
+        return currenttip;
+    }
+
+    @Override
+    public List<String> getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
+        return currenttip;
+    }
+
+    @Override
+    public List<String> getWailaTail(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
+        return currenttip;
+    }
+
+    @Override
+    public NBTTagCompound getNBTData(EntityPlayerMP player, TileEntity te, NBTTagCompound tag, World world, BlockPos pos) {
+        return tag;
+    }
+}

--- a/src/main/java/com/agriculturalexpansion/proxy/CommonProxy.java
+++ b/src/main/java/com/agriculturalexpansion/proxy/CommonProxy.java
@@ -5,6 +5,7 @@ import com.agriculturalexpansion.init.AEBlocks;
 import com.agriculturalexpansion.init.AEItems;
 
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
@@ -17,6 +18,7 @@ public class CommonProxy {
 		
 		Recipes.init();
 
+		FMLInterModComms.sendMessage("Waila", "register", "com.agriculturalexpansion.compat.WailaDataProvider.callbackRegister");
 	}
 	
 	public void init(FMLInitializationEvent event) {


### PR DESCRIPTION
Crops always show an icon in waila (agriculturalexpansion:crop0)

Changing the inventory model for each crop would also change the default icon.
